### PR TITLE
Login with Credentials instead of env variables

### DIFF
--- a/jenkins-pipeline-scripts/deploy-calance-services/Jenkinsfile
+++ b/jenkins-pipeline-scripts/deploy-calance-services/Jenkinsfile
@@ -61,11 +61,9 @@ node('master') {
 node("$cloudName") {
     container('helm') {
         stage('Logging into registry') {
-            sh '''
-                set +x
-                helm registry login -u $GITHUB_USERNAME -p $GITHUB_PASSWORD ghcr.io
-                set -x
-            '''
+            withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '6e8e3064-2329-46fe-bfa3-b1c54f17e885', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
+                sh "helm registry login -u \$USERNAME -p \$PASSWORD ghcr.io"
+            }
         }
 
         stage('Deploying application') {


### PR DESCRIPTION
This PR is responsible for making changes in the Jenkinsfile.

Helm Login step in the Jenkinsfile was using the environment variables of Jenkins Pod template, so ,it was getting printed in the Agent's template in console output of every run.

So, I am logging in with the credentials stored in the Jenkins directly which restricts the printing of credentials in the console output.