### PR TITLE
New changes for URL values on Jenkinsfile

### DIFF
--- a/jenkins-pipeline-scripts/deploy-on-ec2-agent/Jenkinsfile
+++ b/jenkins-pipeline-scripts/deploy-on-ec2-agent/Jenkinsfile
@@ -88,8 +88,9 @@ node("$cloudName"){
         keyValuePairs.each { pair ->
             def keyValue = pair.split(":")
             def key = keyValue[0].replaceAll("\"", "").trim()
-            def value = keyValue[1].replaceAll("\"", "").trim()
-            dockerCommand += " -e ${key}=${value}"
+          //  def value = keyValue[1].replaceAll("\"", "").trim()
+            def value = keyValue[1..-1].join(":").replaceAll("\"", "").trim() // Join the value parts after splitting
+            dockerCommand += " -e ${key}='${value}'"
 
             // maskedDockerCommand will print the running command for debugging but masks the environment secrets
             maskedDockerCommand += " -e ${key}=***"
@@ -122,4 +123,4 @@ node("$cloudName"){
             set -x
         """
     }
-}       
+}


### PR DESCRIPTION
New changes in Jenkinsfile to handle multiple colon(delimiter) in  value field.
We have made changes to ensure that values containing colons are treated as a single string and are preserved in their entirety without splitting. This is achieved by joining the value parts back together after splitting by colons and wrapping the value in single quotes before adding it to the docker Command.

For example:
"DB_CONNECTION_STRING": "mysql://user:password@db.example.com:3306/database"

This will be treated as 

DB_CONNECTION_STRING='mysql://user:password@db.example.com:3306/database'

