### PR TITLE
Added support for multiple volume mounts

### DIFF
--- a/.github/workflows/deploy-on-ec2.yml
+++ b/.github/workflows/deploy-on-ec2.yml
@@ -45,7 +45,7 @@ on:
                 required: true
                 type: string
             mount_path:
-                description: "Mount Path"
+                description: "Mount Path (For multiple volume mounts, add a comma seperated string)"
                 required: false
                 type: string
         secrets:

--- a/jenkins-pipeline-scripts/deploy-on-ec2-agent/Jenkinsfile
+++ b/jenkins-pipeline-scripts/deploy-on-ec2-agent/Jenkinsfile
@@ -14,8 +14,13 @@ def maskedDockerCommand = dockerCommand
 if (MOUNT_PATH){
 
     // There are some applications which do not require mounting
-    dockerCommand += "-v $MOUNT_PATH "
-    maskedDockerCommand += "-v $MOUNT_PATH "
+    MOUNT_PATH = MOUNT_PATH.split(",")
+    
+    for(int i = 0; i < MOUNT_PATH.size(); i++)
+    {
+        dockerCommand += "-v " + MOUNT_PATH[i] + " "
+        maskedDockerCommand += "-v " + MOUNT_PATH[i] + " "
+    }
 }
 
 if (PORT){


### PR DESCRIPTION
This PR is responsible for providing support for multiple volume mounts in the deploy-on-ec2.yml workflow.

Now, you just had to pass multiple volume paths separated by a comma like this:- "/etc/a , /etc/b, /etc/c" 