### PR TITLE
Added support for passing release tag of cwf to jenkins job 

### DIFF
--- a/.github/workflows/deploy-on-ec2.yml
+++ b/.github/workflows/deploy-on-ec2.yml
@@ -52,6 +52,17 @@ on:
                 description: "Enable if container requires GPU"
                 required: false
                 type: boolean
+            jenkins_job_name:
+                description: Name of Jenkins Job Name
+                    For deployment of Protocol Scoring Applications => Protocol Scoring Deployment
+                    For deployment of Calance Applications => EC2-Deployment-Dashboard
+                required: true
+                type: string
+            release_tag:
+                description: Release Tag of current deployment
+                    If you are using deploy-on-ec2.yml@v1.0.8, then release_tag => v1.0.8
+                required: true
+                type: string    
         secrets:
             JENKINS_URL:
                 required: true
@@ -79,7 +90,7 @@ jobs:
             jenkins-url: "${{ secrets.JENKINS_URL }}"
             jenkins-token: "${{ secrets.JENKINS_TOKEN }}"
             user: "${{ secrets.JENKINS_USER }}"
-            job-path: "job/EC2-Deployment-Dashboard"
+            job-path: "job/${{ inputs.jenkins_job_name }}"
             job-params: |
                 {
                     "IMAGE_NAME" : "${{ inputs.image_name }}",
@@ -94,6 +105,7 @@ jobs:
                     "DOCKER_NETWORK": "${{ inputs.docker_network }}",
                     "MOUNT_PATH": "${{ inputs.mount_path }}",
                     "ENABLE_GPU": "${{ inputs.enable_gpu }}",
+                    "RELEASE_TAG": "${{ inputs.release_tag }}",
                     "AWS_ACCESS_KEY_ID": "${{ secrets.AWS_ACCESS_KEY_ID }}",
                     "AWS_SECRET_ACCESS_KEY": "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
                 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,11 @@ on:
           For deployment to Finca Cluster => Finca Deployment
         required: true
         type: string
+      release_tag:
+        description: Release Tag of current deployment
+          If you are using deploy.yml@v1.0.8, then release_tag => v1.0.8
+        required: true
+        type: string
       helm_values_repository:
         description: Name of repo that has helm values files
         required: true
@@ -85,5 +90,6 @@ jobs:
               "VERSION": "${{ inputs.version }}", 
               "COMMIT_ID": "${{ inputs.commit_id }}",
               "IMAGE_REGISTRY": "${{ inputs.image_registry }}",
+              "RELEASE_TAG": "${{ inputs.release_tag }}",
               "HELM_VALUES_REPOSITORY": "${{ inputs.helm_values_repository }}"
             }


### PR DESCRIPTION
This PR is responsible for adding support of passing release tag to Jenkins job so that we can checkout to that release for Jenkinsfile.

It also provides support for parameterized jenkins job in deploy-on-ec2.yml file